### PR TITLE
Database Persistence

### DIFF
--- a/Code/pyproject.toml
+++ b/Code/pyproject.toml
@@ -4,6 +4,7 @@
 # Start code sources: 
 # - [Flask docs on packages](https://flask.palletsprojects.com/en/2.3.x/patterns/packages/)
 # - [Flask docs tutorial: Test Coverage] (https://flask.palletsprojects.com/en/3.0.x/tutorial/tests/#running-the-tests)
+# ---------------------------------------
 
 [project]
 name = "weatherApp"

--- a/Code/tests/test_db.py
+++ b/Code/tests/test_db.py
@@ -28,10 +28,9 @@ def test_get_close_db(app):
 
     assert 'closed' in str(e.value)
 
-# test using inti-db command
+# test using init-db command
 '''
 The init-db command should call the init_db function and output a message.
-It's kinda weird that this test passes when we can't even figure that code out ourselves.
 '''
 def test_init_db_command(runner, monkeypatch):
     class Recorder(object):

--- a/Code/tests/test_views.py
+++ b/Code/tests/test_views.py
@@ -1,7 +1,7 @@
 # ------------------------------------------------
-# test_weatherApp.py
+# test_views.py
 '''
-I created this file as part of a flask testing tutorial.
+This currently exists to test (mostly front end stuff) in views.py
 In the future we will create several test files. (see test_example)
 '''
 '''
@@ -17,6 +17,8 @@ def test_home(client):
     # check that the page has something we know is going to be there
     assert b"<title>Home</title>" in response.data
 
-def test_weather_summary():
+# this test doesn't do much, but it forces the CI pipeline to try to access the /weather_summary page
+def test_weather_summary(client):
+    response = client.get("/weather_summary")
 
-    assert 1
+    assert b"<title>Weather Summary</title>" in response.data

--- a/Code/tests/test_views.py
+++ b/Code/tests/test_views.py
@@ -10,8 +10,13 @@ Starter Code sources:
 '''
 # ------------------------------------------------
 
+# Example of a test that uses the client fixture
 def test_home(client):
     response = client.get("/")
 
     # check that the page has something we know is going to be there
     assert b"<title>Home</title>" in response.data
+
+def test_weather_summary():
+
+    assert 1

--- a/Code/weatherApp/__init__.py
+++ b/Code/weatherApp/__init__.py
@@ -43,10 +43,6 @@ def create_app(test_config=None):
     from . import db
     db.init_app(app)
     
-    # Initialize the database
-    with app.app_context():
-        db.init_db()
-    
     # Import and register blueprints
     from .views import bp as app_blueprint
     app.register_blueprint(app_blueprint)

--- a/Code/weatherApp/__init__.py
+++ b/Code/weatherApp/__init__.py
@@ -11,7 +11,7 @@ This is run automatically when you run the app using the terminal command:
 '''
 '''
 Starter code sources:
-- [Flask docs tutorial - Application Setup] (https://flask.palletsprojects.com/en/3.0.x/tutorial/factory/]
+- [Flask docs tutorial - Application Setup] (https://flask.palletsprojects.com/en/3.0.x/tutorial/factory/)
 - [Flask docs tutorial - Define and Access the Database](https://flask.palletsprojects.com/en/3.0.x/tutorial/database/)
 '''
 #--------------------------------------------------------
@@ -43,14 +43,14 @@ def create_app(test_config=None):
     from . import db
     db.init_app(app)
     
-    # Import and register blueprints
-    from .views import bp as app_blueprint
-    app.register_blueprint(app_blueprint)
-    
     # Initialize the database
     with app.app_context():
         db.init_db()
     
+    # Import and register blueprints
+    from .views import bp as app_blueprint
+    app.register_blueprint(app_blueprint)
+
     #views MUSt be imported at bottom of function in order for app initialization to work (even tho it's a circular import)
     import weatherApp.views
     

--- a/Code/weatherApp/__init__.py
+++ b/Code/weatherApp/__init__.py
@@ -46,8 +46,5 @@ def create_app(test_config=None):
     # Import and register blueprints
     from .views import bp as app_blueprint
     app.register_blueprint(app_blueprint)
-
-    #views MUSt be imported at bottom of function in order for app initialization to work (even tho it's a circular import)
-    import weatherApp.views
     
     return app

--- a/Code/weatherApp/__init__.py
+++ b/Code/weatherApp/__init__.py
@@ -9,6 +9,11 @@ and loads the data from weatherAUS.csv into the database.
 This is run automatically when you run the app using the terminal command:
 `flask --app weatherApp --debug run`
 '''
+'''
+Starter code sources:
+- [Flask docs tutorial - Application Setup] (https://flask.palletsprojects.com/en/3.0.x/tutorial/factory/]
+- [Flask docs tutorial - Define and Access the Database](https://flask.palletsprojects.com/en/3.0.x/tutorial/database/)
+'''
 #--------------------------------------------------------
 from flask import Flask, render_template, url_for
 import os, csv, sqlite3

--- a/Code/weatherApp/db.py
+++ b/Code/weatherApp/db.py
@@ -1,8 +1,10 @@
 # ------------------------------------------------------
 # db.py
 '''
-Methods for creating, accessing and tearing down the 
+- Methods for creating, accessing and tearing down the 
 database using the specs in schema.sql.
+- To initialize the database, run `flask --app weatherApp init-db` 
+in the terminal.
 '''
 '''
 Starter code source:
@@ -112,7 +114,7 @@ def initialize_cities(cur):
 
 #-------------------------------
 
-#Used for initializing database via command line, I couldn't make it work properly - Eric
+# Defines the terminal command used to initialize database: `flask --app weatherApp init-db`
 @click.command('init-db')
 @with_appcontext
 def init_db_command():
@@ -120,7 +122,7 @@ def init_db_command():
     init_db()
     click.echo('Initialized the database.')
 
-#Used to initialized database commands
+#Used to initialize database commands in app factory
 def init_app(app):
     app.teardown_appcontext(close_db)
     app.cli.add_command(init_db_command)

--- a/Code/weatherApp/db.py
+++ b/Code/weatherApp/db.py
@@ -4,6 +4,10 @@
 Methods for creating, accessing and tearing down the 
 database using the specs in schema.sql.
 '''
+'''
+Starter code source:
+- [Flask docs tutorial - Define and Access the Database](https://flask.palletsprojects.com/en/3.0.x/tutorial/database/)
+'''
 # ------------------------------------------------------
 import sqlite3
 import click

--- a/Code/weatherApp/views.py
+++ b/Code/weatherApp/views.py
@@ -14,6 +14,10 @@ contains the view methods associated with it. (right now
 we only have one blueprint called 'bp', registered in this
 file, and all our view methods use it.)
 '''
+'''
+Start Code sources:
+- [Flask docs tutorial - Application Setup](https://flask.palletsprojects.com/en/3.0.x/tutorial/factory/)
+'''
 # ------------------------------------------------------
 from flask import Flask, render_template, Blueprint, current_app, url_for
 from . import db


### PR DESCRIPTION
Database no longer gets re-initialized every time you run the app. Instead, you only have to initialize it once on your local machine using `flask --app weatherApp init-db`. You can also re-initialize it using the same command if you run into problems. 

The unit tests (and therefore the CI workflow) initialize their own instance of the database with the `app` fixture.