### PR TITLE
Dark Mode Graphs and fix for flashing

### DIFF
--- a/Code/weatherApp/graphs.py
+++ b/Code/weatherApp/graphs.py
@@ -96,7 +96,9 @@ def get_7_day_temp_graph_html( city_name, end_date):
         
         graph = TemperatureGraph(graph_args)
         graph.fig.update_layout(
-            height=300
+            margin_r = 0,
+            height=285,
+            width=550
         )
 
         dark_graph = copy.deepcopy(graph)

--- a/Code/weatherApp/graphs.py
+++ b/Code/weatherApp/graphs.py
@@ -227,6 +227,7 @@ class TemperatureGraph(WeatherGraph):
             y = ['Low', 'High'],
             barmode = 'group',
             labels = {"value": "Temperature (°C)", "variable": "Type"},
+            width = 1100
         )
 
         self.fig.update_traces(
@@ -257,9 +258,11 @@ class RainGraph(WeatherGraph):
             self.dataframe,
             x = 'Date',
             y = 'Rainfall',
-            labels = {"value": "Rainfall (mm)"},
+            width = 1100
         )
-
+        self.fig.update_layout(
+            yaxis_title = "Rainfall (mm)"
+        )
         self.fig.update_traces(
             marker_line_width=0.1
         )

--- a/Code/weatherApp/graphs.py
+++ b/Code/weatherApp/graphs.py
@@ -32,8 +32,9 @@ def get_graph_html(url_args=DEFAULT_url_args):
     '''
     light_graph = _get_graph(url_args)
     dark_graph = _get_graph(url_args)
-    dark_graph.convert_to_darkmode()
 
+    if (isinstance(dark_graph, WeatherGraph)):
+        dark_graph.convert_to_darkmode()
 
     return {
         'light': _get_graph_as_string(light_graph),

--- a/Code/weatherApp/graphs.py
+++ b/Code/weatherApp/graphs.py
@@ -203,6 +203,15 @@ class TemperatureGraph(WeatherGraph):
     def __init__(self, city_and_dates):
         super().__init__(city_and_dates)
 
+    # extend parent method
+    def convert_to_darkmode(self):
+        super().convert_to_darkmode()
+
+        self.fig.update_traces(
+            marker_color='#a09cfd',
+            selector={'name':'Low'}
+        )
+
     # OVERRIDE: all abstract methods
     # ------------------------------
     def _fetch_and_convert_data(self):
@@ -240,6 +249,14 @@ class RainGraph(WeatherGraph):
     def __init__(self, city_and_dates):
         super().__init__(city_and_dates)
         print(self.fig)
+
+    # extend parent method
+    def convert_to_darkmode(self):
+        super().convert_to_darkmode()
+
+        self.fig.update_traces(
+            marker_color='#a09cfd'
+        )
 
     # OVERRIDE: all abstract methods
     # ------------------------------

--- a/Code/weatherApp/graphs.py
+++ b/Code/weatherApp/graphs.py
@@ -86,7 +86,7 @@ def _get_graph_as_string(graph):
 def get_7_day_temp_graph_html( city_name, end_date):
     try:
         date_arg = datetime.strptime(end_date, '%Y-%m-%d')
-        start_date = (date_arg - timedelta(days=7)).strftime('%Y-%m-%d')
+        start_date = (date_arg - timedelta(days=6)).strftime('%Y-%m-%d')
         
         graph_args = {
             'city_name' : city_name,

--- a/Code/weatherApp/graphs.py
+++ b/Code/weatherApp/graphs.py
@@ -149,6 +149,16 @@ class WeatherGraph(ABC):
             gridcolor = '#424843',
             zerolinecolor = '#424843'
         )
+        self.fig.update_polars(
+            bgcolor = '#5a605b',
+            angularaxis_gridcolor = '#424843',
+            radialaxis_gridcolor = '#424843',
+            angularaxis_linecolor = '#424843',
+            radialaxis_linecolor = '#424843'
+        )
+        self.fig.update_traces(
+            marker_line_color = '#424843'
+        )
 
 # =================================
 class TemperatureGraph(WeatherGraph):
@@ -228,13 +238,6 @@ class WindGraph(WeatherGraph):
         super()._initialize_dataframe()
         self._initialize_freq_table()
 
-    def convert_to_darkmode(self):
-        super().convert_to_darkmode()
-        self.fig.update_polars(
-            bgcolor = '#5a605b',
-            angularaxis_gridcolor = '#424843',
-            radialaxis_gridcolor = '#424843'
-        )
     # OVERRIDE: all abstract methods
     # ------------------------------
     def _fetch_and_convert_data(self):

--- a/Code/weatherApp/graphs.py
+++ b/Code/weatherApp/graphs.py
@@ -30,8 +30,15 @@ def get_graph_html(url_args=DEFAULT_url_args):
     USE THIS outside of graphs.py
     Note: this function was written this way to make it easier to test the other get graph functions.
     '''
-    graph = _get_graph(url_args)
-    return _get_graph_as_string(graph)
+    light_graph = _get_graph(url_args)
+    dark_graph = _get_graph(url_args)
+    dark_graph.convert_to_darkmode()
+
+
+    return {
+        'light': _get_graph_as_string(light_graph),
+        'dark': _get_graph_as_string(dark_graph)
+    }
 
 def _date_range_is_valid(dates: dict):
     if dates['start_date'] < dates['end_date']:
@@ -89,7 +96,7 @@ class WeatherGraph(ABC):
     
     def get_city_name(self):
         return queries.add_space(self.city_and_dates['city_name'])
-   
+
     # DATAFRAME METHODS
     # ----------------
     def _initialize_dataframe(self):
@@ -128,6 +135,19 @@ class WeatherGraph(ABC):
         self.fig.update_layout(
             margin={'t': 20, 'r': 10, 'l': 10, 'b':20},
             plot_bgcolor = '#e1f4ff'
+        )
+    
+    def convert_to_darkmode(self):
+        self.fig.update_layout(
+            margin={'t': 20, 'r': 10, 'l': 10, 'b':20},
+            paper_bgcolor = '#424843',
+            plot_bgcolor = '#5a605b',
+            font_color = '#fff',
+            legend_title_font_color = '#fff',
+        )
+        self.fig.update_yaxes(
+            gridcolor = '#424843',
+            zerolinecolor = '#424843'
         )
 
 # =================================
@@ -203,11 +223,18 @@ class WindGraph(WeatherGraph):
         self.freq_table = None
         super().__init__(city_and_dates)
 
-    # Overide parent method
+    # Overide parent methods
     def _initialize_dataframe(self):
         super()._initialize_dataframe()
         self._initialize_freq_table()
 
+    def convert_to_darkmode(self):
+        super().convert_to_darkmode()
+        self.fig.update_polars(
+            bgcolor = '#5a605b',
+            angularaxis_gridcolor = '#424843',
+            radialaxis_gridcolor = '#424843'
+        )
     # OVERRIDE: all abstract methods
     # ------------------------------
     def _fetch_and_convert_data(self):

--- a/Code/weatherApp/graphs.py
+++ b/Code/weatherApp/graphs.py
@@ -14,6 +14,8 @@ Resources used:
 import plotly.express as px
 from pandas import DataFrame, crosstab, cut
 from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
+import copy
 from . import queries
 
 DEFAULT_url_args = {
@@ -79,6 +81,39 @@ def _get_graph_as_string(graph):
         return "There was an error generating this graph."
     else:
         return graph.get_html()
+# -------------------------------
+# special function for getting weather summary lil temp graph
+def get_7_day_temp_graph_html( city_name, end_date):
+    try:
+        date_arg = datetime.strptime(end_date, '%Y-%m-%d')
+        start_date = (date_arg - timedelta(days=7)).strftime('%Y-%m-%d')
+        
+        graph_args = {
+            'city_name' : city_name,
+            'start_date' : start_date,
+            'end_date' : end_date
+        }
+        
+        graph = TemperatureGraph(graph_args)
+        graph.fig.update_layout(
+            height=300
+        )
+
+        dark_graph = copy.deepcopy(graph)
+        dark_graph.convert_to_darkmode()
+
+        graph_html = {
+            'light': graph.get_html(),
+            'dark': dark_graph.get_html(),
+        }
+
+    except: 
+        graph_html = {
+            'dark': "Error generating graph.",
+            'light': "Error generating graph."
+        }
+
+    return graph_html
 
 # ==================================
 class WeatherGraph(ABC):

--- a/Code/weatherApp/static/css/style.css
+++ b/Code/weatherApp/static/css/style.css
@@ -119,7 +119,8 @@ input[type=submit] { align-self: start; min-width: 10em; }
   margin: auto;
 }
 
-/* Custom Button Stuff */
+/* ooooooooooooooooooooo Buttons ooooooooooooooooooooooooooooo */
+/* Link Buttons */
 .button-container {
   display: flex;
   flex-direction: row;
@@ -139,6 +140,20 @@ input[type=submit] { align-self: start; min-width: 10em; }
   border-radius: 6px;
   width: 80%; /* Sets a specific width for all buttons */
   max-width: 200px; /* Adjusts maximum width */
+}
+
+/* Dark mode toggle button */
+#mode-toggle-button {
+  background-color: #4b6e52;
+  color: #fff;
+  border: 0px;
+  border-radius: 6px;
+  font-size: 70%;
+  font-weight: bold;
+  padding: 5px;
+}
+#mode-toggle-button:hover {
+  background-color: #161d17;
 }
 
 /* ((((((((((((((((((( FLEXBOXES ))))))))))))))))))) */
@@ -223,7 +238,6 @@ input[type=submit] { align-self: start; min-width: 10em; }
 /* ================= Dark mode ==================== */
 /* https://www.w3schools.com/howto/howto_js_toggle_dark_mode.asp */
 
-/* Dark and twisted versions */
 body.dark-mode,
 body.darkmode .select-table option, 
 body.darkmode .select-table button {
@@ -240,7 +254,6 @@ body.dark-mode .select-table {
   background-color: #161d17;
   color: #fff; 
 }
-
 
 body.dark-mode a {
   color: #6dad7a
@@ -265,24 +278,10 @@ body.dark-mode .select-table td {
   color: #fff; 
 }
 
-/* Dark Mode toggle stuff */
-#mode-toggle-button {
-  background-color: #4b6e52;
-  color: #fff;
-  border: 0px;
-  border-radius: 6px;
-  font-size: 70%;
-  font-weight: bold;
-  padding: 5px;
-}
-#mode-toggle-button:hover {
-  background-color: #161d17;
-}
-
 body.dark-mode #mode-toggle-button {
-  background-color: #FFCD00;
+  background-color: #ffe8a3;
   color: #00843D;
 }
 body.dark-mode #mode-toggle-button:hover {
-  background-color: #ffe8a3;
+  background-color: #FFCD00;
 }

--- a/Code/weatherApp/static/css/style.css
+++ b/Code/weatherApp/static/css/style.css
@@ -26,7 +26,7 @@ nav { background: #FFCD00; display: flex; align-items: center; padding: 0 0.5rem
 nav h1 { flex: auto; margin: 0; }
 nav h1 a { text-decoration: none; padding: 0.25rem 0.5rem; }
 nav ul  { display: flex; list-style: none; margin: 0; padding: 0; }
-nav ul li a, nav ul li span, header .action { display: block; font-size: 0.85rem; padding: 0.5rem; }
+nav ul li a, nav ul li span, header .action { display: block; font-size: 1rem; padding: 0.5rem; }
 
 /* CUSTOM CLASSES WE GOT FROM THE FLASKR TUTORIAL (but tweaked ourselves) */
 .content { padding: 0 1rem 1rem;}
@@ -266,55 +266,23 @@ body.dark-mode .select-table td {
 }
 
 /* Dark Mode toggle stuff */
-.switch {
-  position: relative;
-  display: inline-block;
-  width: 60px;
-  height: 34px;
+#mode-toggle-button {
+  background-color: #4b6e52;
+  color: #fff;
+  border: 0px;
+  border-radius: 6px;
+  font-size: 70%;
+  font-weight: bold;
+  padding: 5px;
+}
+#mode-toggle-button:hover {
+  background-color: #161d17;
 }
 
-.switch input { 
-  opacity: 0;
-  width: 0;
-  height: 0;
+body.dark-mode #mode-toggle-button {
+  background-color: #FFCD00;
+  color: #00843D;
 }
-
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: #000;
-  -webkit-transition: .4s;
-  transition: .4s;
-  border-radius: 34px;
-}
-
-.slider:before {
-  position: absolute;
-  content: "";
-  height: 26px;
-  width: 26px;
-  left: 4px;
-  bottom: 4px;
-  background-color: #fff;
-  -webkit-transition: .4s;
-  transition: .4s;
-  border-radius: 50%;
-}
-
-input:checked + .slider {
-  background-color: #fff;
-}
-
-input:focus + .slider {
-  box-shadow: 0 0 1px #fff;
-}
-
-input:checked + .slider:before {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(26px);
-  transform: translateX(26px);
+body.dark-mode #mode-toggle-button:hover {
+  background-color: #ffe8a3;
 }

--- a/Code/weatherApp/static/css/style.css
+++ b/Code/weatherApp/static/css/style.css
@@ -285,3 +285,8 @@ body.dark-mode #mode-toggle-button {
 body.dark-mode #mode-toggle-button:hover {
   background-color: #FFCD00;
 }
+
+/* Stuff for making graphs darkmode */
+#light-mode-graph, #dark-mode-graph {
+  display: none; /* this is the default, so that you don't get weird flashing on first page load */
+}

--- a/Code/weatherApp/static/css/style.css
+++ b/Code/weatherApp/static/css/style.css
@@ -177,6 +177,10 @@ input[type=submit] { align-self: start; min-width: 10em; }
   grid-row: 1 / 2;
   justify-self: end;
 }
+#all-except-weather-details .graph-container {
+  display: flex;
+  justify-content: center;
+}
 .weather-summary-grid > #weather-details {
   grid-column: 2 / 3;
   grid-row: 1 / 2;
@@ -233,6 +237,9 @@ input[type=submit] { align-self: start; min-width: 10em; }
   grid-row: 3 / 4;
   justify-self: stretch;
   padding: 0px 20px 20px 20px;
+
+  display: flex;
+  flex-direction: column;
 }
 
 /* ================= Dark mode ==================== */

--- a/Code/weatherApp/static/css/style.css
+++ b/Code/weatherApp/static/css/style.css
@@ -220,44 +220,41 @@ input[type=submit] { align-self: start; min-width: 10em; }
   padding: 0px 20px 20px 20px;
 }
 
+/* ================= Dark mode ==================== */
+/* https://www.w3schools.com/howto/howto_js_toggle_dark_mode.asp */
 
-.centered-content {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-}
-
-
-/* Dark mode
-https://www.w3schools.com/howto/howto_js_toggle_dark_mode.asp
- */
-/* Dark mode */
-body.dark-mode {
-  background-color: #666; 
-}
-body.dark-mode {
+/* Dark and twisted versions */
+body.dark-mode,
+body.darkmode .select-table option, 
+body.darkmode .select-table button {
+  background-color: #424843; 
   color: #fff;
 }
 
+body.darkmode nav img {
+  opacity: 0.1; /* this isn't working and i don't know why*/
+}
 body.dark-mode nav,
 body.dark-mode .button-style,
 body.dark-mode .select-table {
-  background-color: #2a2a2a; 
+  background-color: #161d17;
   color: #fff; 
 }
 
+
 body.dark-mode h1,
-body.dark-mode a,
+body.dark-mode a {
+  color: #529f66
+}
+
 body.dark-mode .post .about,
 body.dark-mode input[type="submit"],
 body.dark-mode .button-style {
   color: #fff; 
 }
 
-
 body.dark-mode .info-widget {
-  background-color: #333; 
+  background-color: #5a605b; 
   color: #fff; 
 }
 body.dark-mode .select-table th,
@@ -265,6 +262,7 @@ body.dark-mode .select-table td {
   color: #fff; 
 }
 
+/* Dark Mode toggle stuff */
 .switch {
   position: relative;
   display: inline-block;

--- a/Code/weatherApp/static/css/style.css
+++ b/Code/weatherApp/static/css/style.css
@@ -30,7 +30,7 @@ nav ul li a, nav ul li span, header .action { display: block; font-size: 0.85rem
 
 /* CUSTOM CLASSES WE GOT FROM THE FLASKR TUTORIAL (but tweaked ourselves) */
 .content { padding: 0 1rem 1rem;}
-.content > header { border-bottom: 1px solid lightgray; display: flex; align-items: flex-end; text-align: center}
+.content > header { display: flex; align-items: flex-end; text-align: center}
 .content > header h1 { flex: auto; font-size: 2.75rem; margin: 1rem 0 0.25rem 0;}
 .flash { margin: 1em 0; padding: 1em; background: #cae6f6; border: 1px solid #377ba8; }
 .post > header { display: flex; align-items: flex-end; font-size: 0.85em; }
@@ -242,9 +242,12 @@ body.dark-mode .select-table {
 }
 
 
-body.dark-mode h1,
 body.dark-mode a {
-  color: #529f66
+  color: #6dad7a
+}
+
+body.dark-mode header h1 {
+  color: #6dad7a
 }
 
 body.dark-mode .post .about,

--- a/Code/weatherApp/static/js/darkmode.js
+++ b/Code/weatherApp/static/js/darkmode.js
@@ -42,3 +42,22 @@ function updateToggleText() {
         button.innerHTML = "DARK<br>MODE";
     }
 }
+
+function updateGraph() {
+    var darkModeGraph = document.getElementById("dark-mode-graph");
+    var lightModeGraph = document.getElementById("light-mode-graph");
+
+    if (darkModeIsEnabled()) {
+        darkModeGraph.style.display = "block";
+        lightModeGraph.style.display = "none";
+    }
+    else {
+        darkModeGraph.style.display = "none";
+        lightModeGraph.style.display = "block";
+    }
+}
+
+function updateTextAndGraph() {
+    updateToggleText();
+    updateGraph();
+}

--- a/Code/weatherApp/static/js/darkmode.js
+++ b/Code/weatherApp/static/js/darkmode.js
@@ -28,11 +28,17 @@ function loadPageWithCorrectMode() {
     }
 }
 
-function onToggleSwitchMode() {
-    const darkModeToggle = document.getElementById('darkModeToggle');
+function switchAndLoadMode() {
+    switchMode();
+    loadPageWithCorrectMode();
+}
 
-    darkModeToggle.addEventListener('change', function() {
-        switchMode();
-        loadPageWithCorrectMode();
-    });
+function updateToggleText() {
+    const button = document.getElementById('mode-toggle-button');
+    if (darkModeIsEnabled()) {
+        button.innerHTML = "LIGHT<br>MODE";
+    }
+    else {
+        button.innerHTML = "DARK<br>MODE";
+    }
 }

--- a/Code/weatherApp/static/js/darkmode.js
+++ b/Code/weatherApp/static/js/darkmode.js
@@ -1,35 +1,38 @@
-function toggleDarkMode() {
+// ----------------------------------------------------
+// darkmode.js
+/*
+Functions for controlling website darkmode.
+*/
+// -----------------------------------------------------
+
+function darkModeIsEnabled() {
+    return localStorage.getItem('darkMode') === 'enabled'
+}
+
+function switchMode() {
+    if (darkModeIsEnabled()) {
+        localStorage.setItem('darkMode', 'disabled');
+    }
+    else {
+        localStorage.setItem('darkMode', 'enabled');
+    }
+}
+
+function loadPageWithCorrectMode() {
     const body = document.getElementById('body');
-    const darkModeEnabled = localStorage.getItem('darkMode') === 'enabled';
     
-    if (darkModeEnabled) {
+    if (darkModeIsEnabled()) {
         body.classList.add('dark-mode');
     } else {
         body.classList.remove('dark-mode');
     }
-    
 }
 
-function saveDarkModePreference() {
+function onToggleSwitchMode() {
     const darkModeToggle = document.getElementById('darkModeToggle');
+
     darkModeToggle.addEventListener('change', function() {
-        const darkModeEnabled = this.checked;
-        localStorage.setItem('darkMode', darkModeEnabled ? 'enabled' : 'disabled');
-        toggleDarkMode();
+        switchMode();
+        loadPageWithCorrectMode();
     });
 }
-
-// Call toggleDarkMode on page load
-document.addEventListener('DOMContentLoaded', function() {
-    toggleDarkMode();
-});
-
-// Call toggleDarkMode whenever dark mode preference changes
-window.addEventListener('storage', function(event) {
-    if (event.key === 'darkMode') {
-        toggleDarkMode();
-    }
-});
-
-// Save dark mode preference when toggled
-saveDarkModePreference();

--- a/Code/weatherApp/templates/admin_dashboard.html.jinja
+++ b/Code/weatherApp/templates/admin_dashboard.html.jinja
@@ -1,6 +1,3 @@
-{% block scripts %}
-  <script src="{{ url_for('static', filename='js/darkmode.js') }}"></script>
-{% endblock %}
 {% extends 'base.html.jinja' %}
 
 {% block title %}

--- a/Code/weatherApp/templates/base.html.jinja
+++ b/Code/weatherApp/templates/base.html.jinja
@@ -13,6 +13,9 @@ FreeCodeCamp "Learn Flask for Python" https://www.youtube.com/watch?v=Z1RJmh_Oqe
     <link href='https://fonts.googleapis.com/css?family=Rubik:700' rel='stylesheet'>
     <link href='https://fonts.googleapis.com/css?family=Roboto' rel='stylesheet'>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+
+    <script src="{{ url_for('static', filename='js/darkmode.js') }}"></script>
+
     {% block head %}{% endblock %}
     
     <title>{% block title %}{% endblock %} - Thunder Down Under
@@ -21,46 +24,52 @@ FreeCodeCamp "Learn Flask for Python" https://www.youtube.com/watch?v=Z1RJmh_Oqe
 </head>
 
 <body id="body">
-<nav>
-    <img src="{{ url_for('static', filename='img/happy_cloud.png') }}" alt="Happy Cloud" height="66" width="76">
-    <h1>
-        <a href="{{ url_for('views.index') }}">THUNDER DOWN UNDER</a>
-    </h1>
-    <ul>
-        {% if g.user %}
-            <li><span>{{ g.user['firstname'] }}</span></li>
-            <li><span> ID: {{ g.user['userid'] }}</span></li>
-            <li><a href="{{ url_for('auth.logout') }}">Log Out</a></li>
-        {% else %}
-            <li><a href="{{ url_for('auth.register') }}">Register</a></li>
-            <li><a href="{{ url_for('auth.login') }}">Log In</a></li>
-        {% endif %}
-        <li>
-            <label class="switch">
-                <input type="checkbox" id="darkModeToggle">
-                <span class="slider"></span>
-            </label>
-            
-        </li>
-    </ul>
-</nav>
 
+    <script>
+        loadPageWithCorrectMode()
+    </script>
 
-<section class="content">
-    <header>
-        <h1>{% block header %}{% endblock %}</h1>
-    </header>
+    <nav>
+        <img src="{{ url_for('static', filename='img/happy_cloud.png') }}" alt="Happy Cloud" height="66" width="76">
+        <h1>
+            <a href="{{ url_for('views.index') }}">THUNDER DOWN UNDER</a>
+        </h1>
+        <ul>
+            {% if g.user %}
+                <li><span>{{ g.user['firstname'] }}</span></li>
+                <li><span> ID: {{ g.user['userid'] }}</span></li>
+                <li><a href="{{ url_for('auth.logout') }}">Log Out</a></li>
+            {% else %}
+                <li><a href="{{ url_for('auth.register') }}">Register</a></li>
+                <li><a href="{{ url_for('auth.login') }}">Log In</a></li>
+            {% endif %}
+            <li>
+                <label class="switch">
+                    <input type="checkbox" id="darkModeToggle">
+                    <span class="slider"></span>
+                </label>
+                
+            </li>
+        </ul>
+    </nav>
 
-    {% for message in get_flashed_messages() %}
-        <div class="flash">{{ message }}</div>
-    {% endfor %}
+    <script>
+        onToggleSwitchMode()
+    </script>
 
-    {% block content %}{% endblock %}
-</section>
+    <section class="content">
+        <header>
+            <h1>{% block header %}{% endblock %}</h1>
+        </header>
 
-{% block scripts %}
-<script src="{{ url_for('static', filename='js/darkmode.js') }}"></script>
-{% endblock %}
+        {% for message in get_flashed_messages() %}
+            <div class="flash">{{ message }}</div>
+        {% endfor %}
+
+        {% block content %}{% endblock %}
+    </section>
+
+    {% block scripts %}{% endblock %}
 
 </body>
 </html>

--- a/Code/weatherApp/templates/base.html.jinja
+++ b/Code/weatherApp/templates/base.html.jinja
@@ -44,18 +44,13 @@ FreeCodeCamp "Learn Flask for Python" https://www.youtube.com/watch?v=Z1RJmh_Oqe
                 <li><a href="{{ url_for('auth.login') }}">Log In</a></li>
             {% endif %}
             <li>
-                <label class="switch">
-                    <input type="checkbox" id="darkModeToggle">
-                    <span class="slider"></span>
-                </label>
-                
+                <button onclick="switchAndLoadMode(); updateToggleText();" id="mode-toggle-button"></button>
+                <script>
+                    updateToggleText(); // so that buttons loads with text when page is loaded.
+                </script>
             </li>
         </ul>
     </nav>
-
-    <script>
-        onToggleSwitchMode()
-    </script>
 
     <section class="content">
         <header>

--- a/Code/weatherApp/templates/base.html.jinja
+++ b/Code/weatherApp/templates/base.html.jinja
@@ -23,8 +23,9 @@ FreeCodeCamp "Learn Flask for Python" https://www.youtube.com/watch?v=Z1RJmh_Oqe
 <body id="body">
 <nav>
     <img src="{{ url_for('static', filename='img/happy_cloud.png') }}" alt="Happy Cloud" height="66" width="76">
-    <h1><a href="{{ url_for('views.index') }}">Thunder Down Under
-    </a></h1>
+    <h1>
+        <a href="{{ url_for('views.index') }}">THUNDER DOWN UNDER</a>
+    </h1>
     <ul>
         {% if g.user %}
             <li><span>{{ g.user['firstname'] }}</span></li>

--- a/Code/weatherApp/templates/base.html.jinja
+++ b/Code/weatherApp/templates/base.html.jinja
@@ -44,9 +44,9 @@ FreeCodeCamp "Learn Flask for Python" https://www.youtube.com/watch?v=Z1RJmh_Oqe
                 <li><a href="{{ url_for('auth.login') }}">Log In</a></li>
             {% endif %}
             <li>
-                <button onclick="switchAndLoadMode(); updateToggleText();" id="mode-toggle-button"></button>
+                <button onclick="switchAndLoadMode(); updateTextAndGraph();" id="mode-toggle-button"></button>
                 <script>
-                    updateToggleText(); // so that buttons loads with text when page is loaded.
+                    updateToggleText(); // called here for initial page load
                 </script>
             </li>
         </ul>
@@ -64,7 +64,8 @@ FreeCodeCamp "Learn Flask for Python" https://www.youtube.com/watch?v=Z1RJmh_Oqe
         {% block content %}{% endblock %}
     </section>
 
-    {% block scripts %}{% endblock %}
+    {% block scripts %}
+    {% endblock %}
 
 </body>
 </html>

--- a/Code/weatherApp/templates/features/graphs.html.jinja
+++ b/Code/weatherApp/templates/features/graphs.html.jinja
@@ -1,12 +1,8 @@
-{% block scripts %}
-  <script src="{{ url_for('static', filename='js/darkmode.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/submit.js') }}"></script>
-{% endblock %}
-
 {# 
 This template expects the following parameters: 
  -- figure_html - a plotly figure object in html string form
  -- url_args - a dictionary with the keys: 
+    - stat
     - city_name
     - start_date
     - end_date
@@ -14,9 +10,6 @@ This template expects the following parameters:
 {% extends "base.html.jinja" %}
 {% import 'helpers/selectors.html.jinja' as selectors %}
 
-
-{% block head %}
-{% endblock %}
 {% block title %}
     Graphs
 {% endblock %}
@@ -75,4 +68,8 @@ This template expects the following parameters:
             {{ graph_html }}
         </div>
     </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ url_for('static', filename='js/submit.js') }}"></script>
 {% endblock %}

--- a/Code/weatherApp/templates/features/graphs.html.jinja
+++ b/Code/weatherApp/templates/features/graphs.html.jinja
@@ -1,6 +1,6 @@
 {# 
 This template expects the following parameters: 
- -- figure_html - a plotly figure object in html string form
+ -- graph_html - a dictionary containing 2 graph objects in html string form (light and dark)
  -- url_args - a dictionary with the keys: 
     - stat
     - city_name
@@ -59,19 +59,18 @@ This template expects the following parameters:
             </h2>
         {% endif %}
 
-        {# TODO: DARKMODE GRAPHS #}
-
         {# embedded graph svg #}
         <div class="visualization"
             {% if url_args['stat'] == 'wind' %}
                 style="justify-self: center; padding-top: 10px"
             {% endif %}
         >
+            {# one of these is hidden and one is shown at all times #}
             <div id="light-mode-graph">
-                {{ graph_html }}
+                {{ graph_html.light }}
             </div>
             <div id="dark-mode-graph">
-                <p> [PUT DARK GRAPH HERE] </p>
+                <p> {{ graph_html.dark }} </p>
             </div>
 
             <script>

--- a/Code/weatherApp/templates/features/graphs.html.jinja
+++ b/Code/weatherApp/templates/features/graphs.html.jinja
@@ -57,20 +57,26 @@ This template expects the following parameters:
             <h2>
                 {{ url_args['stat'].capitalize() }} Data for {{ url_args['city_name'] }} over Time
             </h2>
+            {# <p>
+                If the graph is not centered or seems weirdly small, try zooming in and out in your browser or resizing the window. (This is a documented Plotly bug and we can't fix it right now)
+            </p> #}
         {% endif %}
 
         {# embedded graph svg #}
         <div class="visualization"
             {% if url_args['stat'] == 'wind' %}
                 style="justify-self: center; padding-top: 10px"
+            {% else %}
+                style="justify-self: center;"
             {% endif %}
+         id="vis"
         >
             {# one of these is hidden and one is shown at all times #}
             <div id="light-mode-graph">
                 {{ graph_html.light }}
             </div>
             <div id="dark-mode-graph">
-                <p> {{ graph_html.dark }} </p>
+                {{ graph_html.dark }}
             </div>
 
             <script>

--- a/Code/weatherApp/templates/features/graphs.html.jinja
+++ b/Code/weatherApp/templates/features/graphs.html.jinja
@@ -59,13 +59,24 @@ This template expects the following parameters:
             </h2>
         {% endif %}
 
+        {# TODO: DARKMODE GRAPHS #}
+
         {# embedded graph svg #}
         <div class="visualization"
             {% if url_args['stat'] == 'wind' %}
                 style="justify-self: center; padding-top: 10px"
-            {% endif%}
+            {% endif %}
         >
-            {{ graph_html }}
+            <div id="light-mode-graph">
+                {{ graph_html }}
+            </div>
+            <div id="dark-mode-graph">
+                <p> [PUT DARK GRAPH HERE] </p>
+            </div>
+
+            <script>
+                updateGraph(); // (called here for initial page load)
+            </script>
         </div>
     </div>
 {% endblock %}

--- a/Code/weatherApp/templates/features/weather_summary.html.jinja
+++ b/Code/weatherApp/templates/features/weather_summary.html.jinja
@@ -1,7 +1,3 @@
-{% block scripts %}
-  <script src="{{ url_for('static', filename='js/darkmode.js') }}"></script>
-  <script src="{{ url_for('static', filename='js/submit.js') }}"></script>
-{% endblock %}
 {% extends 'base.html.jinja' %}
 {% import 'helpers/selectors.html.jinja' as selectors %}
 {% import 'helpers/data_display.html.jinja' as data_display %}
@@ -16,7 +12,7 @@
 {% endblock %}
 
 {% block content %}
-<!--possible future div -->
+
 <div class="centered-content">
   <div class="weather-summary-grid">
 
@@ -56,5 +52,9 @@
 
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ url_for('static', filename='js/submit.js') }}"></script>
 {% endblock %}
 

--- a/Code/weatherApp/templates/features/weather_summary.html.jinja
+++ b/Code/weatherApp/templates/features/weather_summary.html.jinja
@@ -19,7 +19,7 @@
     <div id="all-except-weather-details"> <!-- grid item -->
 
       <div class="table-container">
-        <table class='select-table' style="display:flex;"">
+        <table class='select-table' style="display:flex;">
           <tr>
             <th>Location</th>
             <th>Date</th>

--- a/Code/weatherApp/templates/features/weather_summary.html.jinja
+++ b/Code/weatherApp/templates/features/weather_summary.html.jinja
@@ -39,7 +39,17 @@
       {{ data_display.weather_overview(weather_dict, weather_icon, rain_prediction)}}
 
       <div class="graph-container">
-        {{ graph_html }}
+        {# one of these is hidden and one is shown at all times #}
+        <div id="light-mode-graph">
+            {{ graph_html.light }}
+        </div>
+        <div id="dark-mode-graph">
+            {{ graph_html.dark }}
+        </div>
+
+        <script>
+            updateGraph(); // (called here for initial page load)
+        </script>
       </div>
 
     </div>

--- a/Code/weatherApp/templates/index.html.jinja
+++ b/Code/weatherApp/templates/index.html.jinja
@@ -11,9 +11,7 @@ This template expects the following parameters:
 
 {% extends 'base.html.jinja' %}
 {% import 'helpers/data_display.html.jinja' as data_display %}
-{% block scripts %}
-  <script src="{{ url_for('static', filename='js/darkmode.js') }}"></script>
-{% endblock %}
+
 {% block title %}
   Home
 {% endblock %}

--- a/Code/weatherApp/templates/settings.html.jinja
+++ b/Code/weatherApp/templates/settings.html.jinja
@@ -1,6 +1,3 @@
-{% block scripts %}
-  <script src="{{ url_for('static', filename='js/darkmode.js') }}"></script>
-{% endblock %}
 {% extends 'base.html.jinja' %}
 {% import 'helpers/selectors.html.jinja' as selectors %}
 {% block title %}

--- a/Code/weatherApp/views.py
+++ b/Code/weatherApp/views.py
@@ -27,7 +27,7 @@ from . import (
     db,
 )
 from .auth import login_required
-from datetime import datetime, timedelta
+from datetime import datetime
 
 views_bp = Blueprint('views', __name__)
 
@@ -78,26 +78,7 @@ def weather_summary():
     weather_dict = queries.get_weather_data( city_name, date)
     weather_icon = weather.determine_icon_based_on_weather(weather_dict)
     rain_prediction = predictions.predict_rain(city_name, date)
-    
-    # prepare graph
-    try:
-        date_arg = datetime.strptime(date, '%Y-%m-%d')
-        start_date = (date_arg - timedelta(days=7)).strftime('%Y-%m-%d')
-        
-        graph_args = {
-            'city_name' : city_name,
-            'start_date' : start_date,
-            'end_date' : date
-        }
-        
-        graph = graphs.TemperatureGraph(graph_args)
-        graph.fig.update_layout(
-            height=300
-        )
-        graph_html = graph.get_html()
-
-    except: 
-        graph_html = "Error generatign graph."
+    graph_html = graphs.get_7_day_temp_graph_html(city_name, date)
     
     try:
         # Convert date from YYYY-MM-DD into Month DD, YYYY    


### PR DESCRIPTION
## In this branch:
### General Darkmode Changes
- the dark mode colours are more themed
- the slider has been changed to a button. Not as satisfying but it's a pretty neat button.
- `darkmode.js`  and where its functions are used has been significantly changed:
  - the document now ensures the page loads with the correct mode (as opposed to loading with light mode and then switching if necessary). THIS FIXED THE FLASHING YAY
  - the script tags for darkmode are mostly just in `base.html.jinja` now, except in pages with graphs where there is a little JS called near the graphs
  - no functions are called directly from `darkmode.js`

### Dark-mode-able graphs
- graphs switch to dark mode with everything else
- graph logic has been completely moved out of the weather summary view function into a new function in `graphs.py`